### PR TITLE
Add guard not to load plugin twice

### DIFF
--- a/plugin/bclose.vim
+++ b/plugin/bclose.vim
@@ -1,3 +1,8 @@
+if exists('g:loaded_bclose')
+    finish
+endif
+let g:loaded_bclose = 1
+
 "here is a more exotic version of my original Bclose script
 "delete the buffer; keep windows; create a scratch buffer if no buffers left
 function s:Bclose(kwbdStage)


### PR DESCRIPTION
Vim sometimes throws an error that the Bclose command was already defined. This patch makes sure the plugin only gets loaded once.
